### PR TITLE
DD-1905 endpoint voor het opvragen van created timestamp

### DIFF
--- a/src/main/openapi/dd-data-vault-api.yml
+++ b/src/main/openapi/dd-data-vault-api.yml
@@ -34,6 +34,14 @@ paths:
     get:
       operationId: rootGet
       summary: Returns a description of the service.
+      parameters:
+        - name: Accept
+          in: header
+          required: false
+          schema:
+            type: string
+            enum: [ application/json, text/plain ]
+            default: application/json
       responses:
         200:
           description: description of the service
@@ -44,6 +52,9 @@ paths:
                 description: a plain text, human readable description of the service
                 example: |
                   Data Vault API Running (v${project.version})
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppInfo'
 
   /imports:
     get:
@@ -142,6 +153,7 @@ paths:
                 $ref: '#/components/schemas/LayerStatus'
   /objects/{id}/versions/{nr}:
     get:
+      operationId: objectsIdVersionsNrGet
       summary: Returns the properties of the given object version
       parameters:
         - name: id
@@ -165,6 +177,14 @@ paths:
 
 components:
   schemas:
+    AppInfo:
+      type: object
+      properties:
+        name:
+          type: string
+        version:
+          type: string
+
     ImportCommand:
       type: object
       properties:

--- a/src/main/openapi/dd-data-vault-api.yml
+++ b/src/main/openapi/dd-data-vault-api.yml
@@ -32,6 +32,7 @@ info:
 paths:
   /:
     get:
+      operationId: rootGet
       summary: Returns a description of the service.
       responses:
         200:
@@ -46,6 +47,7 @@ paths:
 
   /imports:
     get:
+      operationId: importsGet
       summary: Returns a list of all current import jobs and their status
       responses:
         200:
@@ -57,6 +59,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/ImportJobStatus'
     post:
+      operationId: importsPost
       summary: Submits a new import job
       requestBody:
         content:
@@ -73,6 +76,7 @@ paths:
 
   /imports/{id}:
     get:
+      operationId: importsIdGet
       summary: Returns the import job with the specified id
       parameters:
         - name: id
@@ -94,6 +98,7 @@ paths:
 
   /layers:
     post:
+      operationId: layersPost
       summary: Creates a new top layer, closing and archiving the current top layer
       responses:
         201:
@@ -105,13 +110,15 @@ paths:
 
   /layers/{layerId}:
     get:
+      operationId: layersIdGet
       summary: Returns the status of the layer with the specified id
       parameters:
         - name: layerId
           in: path
           required: true
           schema:
-            type: long
+            type: integer
+            format: int64
           description: The timestamp of the layer, in milliseconds since the epoch
       responses:
         200:
@@ -124,6 +131,7 @@ paths:
           description: No layer with the specified id was found
   /layers/top:
     get:
+      operationId: layersTopGet
       summary: Returns the status of the top layer
       responses:
         200:
@@ -132,6 +140,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LayerStatus'
+  /objects/{id}/versions/{nr}:
+    get:
+      summary: Returns the properties of the given object version
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: nr
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        200:
+          description: Information object the requested version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OcflObjectVersion'
+
 
 components:
   schemas:
@@ -150,7 +180,7 @@ components:
           type: boolean
           default: false
           description: Whether to accept timestamp directories in the batch directory. By default the version directories are expected to be the
-           exact version numbers of the versions to be created.
+            exact version numbers of the versions to be created.
     ImportJobStatus:
       type: object
       properties:
@@ -177,8 +207,21 @@ components:
       type: object
       properties:
         layerId:
-          type: long
+          type: integer
+          format: int64
           description: The timestamp of the layer, in milliseconds since the epoch
         sizeInBytes:
-          type: long
+          type: integer
+          format: int64
           description: The size of the layer in bytes
+
+    OcflObjectVersion:
+      type: object
+      properties:
+        versionNumber:
+          type: integer
+          description: The version number
+        created:
+          type: string
+          format: date-time
+


### PR DESCRIPTION
DD-1905

Copied comments generated by Co-Pilot:

This PR updates the OpenAPI specification to add operationId attributes across several endpoints, introduce a new endpoint for retrieving object version details, and update type definitions for specific fields.  
- Added operationId for paths such as /, /imports, /layers, and /objects/{id}/versions/{nr}.  
- Introduced the new endpoint /objects/{id}/versions/{nr} to retrieve an object's version details.  **This was the main purpose of the PR.**
- Updated data types for identifiers to use integer with an int64 format where previously a long was used. (`long` is not actually a valid Open API type.)

